### PR TITLE
add sync button and sync more often, sync/retry on auth failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,17 @@ pip install -r requirements.txt
 ### 4. Create a ```prod.env``` file to define the following enviroment vaiables:
 #### Note: They are not stored in this repo as they are considered sensitive information.
 
-| Key               | Description                                                                           | Default Value  |
-| ----------------- | ------------------------------------------------------------------------------------- | -------------- |
-| ACE_ACCESS_URL    | the access list URL                                                                   | none, required |
-| ACE_EXPORT_TOKEN  | used with ACE_ACCESS_URL                                                              | none, required |
-| ACEGC_ASSET_ID    | the Assest ID of the pi                                                               | none, required |
-| ACEGC_ASSET_TOKEN | auth token                                                                            | none, required |
-| ACEGC_BASE_URL    | base URL to Grand Central                                                             | none, required |
-| ACEGC_LASER_COST  | the cost in cents per minute of laser firing                                          | 0.5            |
-| LASER_LOGOUT_TIME | number of inactivity minutes which invokes a logout                                   | 40             |
-| LASER_ODO_POLLING | the time interval used to continously poll the laser for odometer reading, in seconds | 15             |
+| Key                  | Description                                                                           | Default Value  |
+| -------------------- | ------------------------------------------------------------------------------------- | -------------- |
+| ACE_ACCESS_URL       | the access list URL                                                                   | none, required |
+| ACE_EXPORT_TOKEN     | used with ACE_ACCESS_URL                                                              | none, required |
+| ACEGC_ASSET_ID       | the Assest ID of the pi                                                               | none, required |
+| ACEGC_ASSET_TOKEN    | auth token                                                                            | none, required |
+| ACEGC_BASE_URL       | base URL to Grand Central                                                             | none, required |
+| ACEGC_LASER_COST     | the cost in cents per minute of laser firing                                          | 0.5            |
+| LASER_LOGOUT_TIME    | number of inactivity minutes which invokes a logout                                   | 40             |
+| LASER_ODO_POLLING    | the time interval used to continously poll the laser for odometer reading, in seconds | 15             |
+| LASERGUI_SYNC_BUTTON | If present, will show a "Force Sync" button in the GUI                                    | Off             |
 
 #### Example `prod.env` file:
 ```toml

--- a/README.md
+++ b/README.md
@@ -408,6 +408,14 @@ requests.get("<ACEGC_BASE_URL>/filters/", headers=header)
 * requirements.txt — python library dependencies
 * sessionManager.py — manages interactions between the GUI and users and filters
 
+### Testing and Local Dev
+
+Set the `LASERGUI_ROOT` env variable to use a different install location for testing. If
+this is not set, the default `/home/pi/laserGui/` will be used.
+
+Set the `LASERGUI_MOCK` to use a mock `Laser` class that will not try and talk
+to the serial port but instead just do nothing. (This is pretty incomplete at the moment, but
+it's enough to let the app run)
 
 -----------------
 # Contributors

--- a/laser.py
+++ b/laser.py
@@ -1,5 +1,5 @@
 import time
-from serial import Serial
+import serial
 
 class Laser:
     '''
@@ -34,7 +34,7 @@ class Laser:
     def __init__(self, port='/dev/ttyACM0', baudrate=9600):
         self.reset_usb()
         time.sleep(1)
-        self.conn = Serial(port, baudrate)
+        self.conn = serial.Serial(port, baudrate)
         self.disable()
         self.odometer = '0'
         self.rfid_flag = '0'

--- a/laser.py
+++ b/laser.py
@@ -1,5 +1,5 @@
 import time
-import serial
+from serial import Serial
 
 class Laser:
     '''
@@ -34,7 +34,7 @@ class Laser:
     def __init__(self, port='/dev/ttyACM0', baudrate=9600):
         self.reset_usb()
         time.sleep(1)
-        self.conn = serial.Serial(port, baudrate)
+        self.conn = Serial(port, baudrate)
         self.disable()
         self.odometer = '0'
         self.rfid_flag = '0'

--- a/laserGui.py
+++ b/laserGui.py
@@ -10,7 +10,6 @@ tkmixins.ColorMixin.BG_KEYS.append( "highlightbackground")
 # Allow overriding default install location for LaserGUI
 LASERGUI_ROOT = os.environ.get( "LASERGUI_ROOT", "/home/pi/laserGui/" )
 
-
 # Contant Color Values
 MAIN_COLOR = "#3636B2"
 FILTER_COLOR = "#222270"
@@ -258,10 +257,14 @@ welcomeBox = Box(app, align="top", width="fill")
 Box(welcomeBox, width="fill", height=60) # spacer
 Text(welcomeBox, text="Welcome", size=72)
 Text(welcomeBox, text="Tap your fob to begin", size=36)
+
 syncTimeText = Text(welcomeBox, text="Last update:", size=12 )
 updateSyncTime()
-btnSyncNow = PushButton( welcomeBox, command=syncAuthList, text="Sync Now", width=10, pady=12 )
-btnSyncNow.highlightbackground = "blue"
+
+# Optionally, show a force sync button
+if 'LASERGUI_SYNC_BUTTON' in os.environ:
+    btnSyncNow = PushButton( welcomeBox, command=syncAuthList, text="Sync Now", width=10, pady=12 )
+    btnSyncNow.highlightbackground = "blue"
 
 
 # UNCERTIFIED State

--- a/mockLaser.py
+++ b/mockLaser.py
@@ -1,0 +1,17 @@
+
+class MockLaser:
+    def __init__(self, port='/dev/ttyACM0', baudrate=9600):
+        self.port = port
+        self.baudrate= baudrate
+        self.enabled = False
+        self.odometer = '0'
+
+    def disable(self):
+        self.enabled = False
+
+    def enable(self):
+        self.enabled = True
+
+    def status(self):
+        self.odometer = '0'
+

--- a/sync_authlist.py
+++ b/sync_authlist.py
@@ -1,0 +1,51 @@
+import os, sys
+import tempfile
+import requests
+
+LASERGUI_ROOT = os.environ.get( "LASERGUI_ROOT", "/home/pi/laserGui/" )
+AUTHLIST_FILE = "authorized.json"
+
+def fetch_access_list():
+    """
+    Pulls certified laser RFIDs from URL defined as an environment variable.
+    The json list contains only those user allowed to use the laser.
+    """
+    ACCESS_URL = os.environ['ACE_ACCESS_URL']
+    EXPORT_TOKEN = os.environ['ACE_EXPORT_TOKEN']
+
+    body = {'ace_export_token': EXPORT_TOKEN}
+    headers = {'User-Agent': 'Wget/1.20.1 (linux-gnu)'}
+    try:
+        response = requests.post(ACCESS_URL, body, headers=headers)
+    except requests.exceptions.Timeout:
+        # TODO  Maybe set up for a retry, or continue in a retry loop
+        print("Timeout connecting to URL")
+        sys.exit(1)
+    except requests.exceptions.TooManyRedirects:
+        # TODO Tell the user their URL was bad and try a different one
+        print("Invalid URL, exiting")
+        sys.exit(1)
+    except requests.exceptions.RequestException as e:
+        print(e)
+        sys.exit(1)
+
+    # print(response.content)
+    # print(response.text)
+
+    data = response.content
+    authlist = os.path.join( LASERGUI_ROOT, AUTHLIST_FILE )
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        tf.write(data)
+        tf.flush()
+
+        # Atomically replace the old authlist
+        os.replace( tf.name, authlist )
+
+
+
+if __name__=='__main__':
+    fetch_access_list()
+
+
+
+


### PR DESCRIPTION
Adds a force sync button and syncs on logout. Sync on failed auth and retry automatically.

It was suggested that syncing from a cron job would be better (e.g. if internet is down would still have a recent list), and I think this is a good idea, so I included a simple "sync_authlist.py" script that can be run from a cron job to pull the auth list. Once this is tested and working we can remove all the fetching from the GUI app to simplify things, but for now it shouldn't hurt to have both methods in there.

